### PR TITLE
chore: scaffold TypeScript project

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  env: { es2020: true, node: true },
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  parserOptions: { sourceType: 'module' },
+  rules: {}
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,7 @@ milestones distilled from the original INPUT.
 
 ## Modules
 These modules will grow as steps are implemented:
+Initial stubs reside under `src/`.
 - `types.ts` – shared type definitions.
 - `worldgen.ts` – physical layer generation.
 - `transport.ts` – network creation and pathfinding.

--- a/docs/master_checklist.md
+++ b/docs/master_checklist.md
@@ -3,7 +3,7 @@
 Consult [`design_overview.md`](design_overview.md) for overall requirements.
 Execute each step in order, marking completion after satisfying the [Definition of Done](definition_of_done.md).
 
-1. [ ] [Step 0: Project Setup](steps/00_project_setup.md)
+1. [x] [Step 0: Project Setup](steps/00_project_setup.md)
 2. [ ] [Step 1: Core World Generation](steps/01_core_world.md)
 3. [ ] [Step 2: Transport Network](steps/02_transport.md)
 4. [ ] [Step 3: Land Use and Settlements](steps/03_growth.md)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import pluginTs from '@typescript-eslint/eslint-plugin';
+import parserTs from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: parserTs,
+      sourceType: 'module',
+    },
+    plugins: { '@typescript-eslint': pluginTs },
+    rules: {
+      // Add project-specific rules here
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "colonies",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint .",
+    "test": "vitest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^0.34.0",
+    "eslint": "^8.0.0",
+    "prettier": "^2.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "ts-node": "^10.0.0"
+  }
+}

--- a/src/export_gif.ts
+++ b/src/export_gif.ts
@@ -1,0 +1,5 @@
+import { Sim } from './types';
+
+export function captureIfDue(sim: Sim, ctx: CanvasRenderingContext2D): void {
+  throw new Error('captureIfDue not implemented');
+}

--- a/src/growth.ts
+++ b/src/growth.ts
@@ -1,0 +1,13 @@
+import { Sim } from './types';
+
+export function updateLandUse(sim: Sim): void {
+  throw new Error('updateLandUse not implemented');
+}
+
+export function updateSettlements(sim: Sim): void {
+  throw new Error('updateSettlements not implemented');
+}
+
+export function updateIndustries(sim: Sim): void {
+  throw new Error('updateIndustries not implemented');
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,5 @@
+import { Sim } from './types';
+
+export function renderFrame(sim: Sim, ctx: WebGL2RenderingContext): void {
+  throw new Error('renderFrame not implemented');
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,21 @@
+import { LandMesh, HydroNetwork, Config, NetState, Sim, ODBundle } from './types';
+
+export function initNetwork(land: LandMesh, hydro: HydroNetwork, cfg: Config): NetState {
+  throw new Error('initNetwork not implemented');
+}
+
+export function edgeCost(heId: number, sim: Sim): number {
+  throw new Error('edgeCost not implemented');
+}
+
+export function buildOD(sim: Sim): ODBundle[] {
+  throw new Error('buildOD not implemented');
+}
+
+export function routeFlowsAndAccumulateUsage(sim: Sim): void {
+  throw new Error('routeFlowsAndAccumulateUsage not implemented');
+}
+
+export function applyUpgrades(sim: Sim): void {
+  throw new Error('applyUpgrades not implemented');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,111 @@
+// Shared type definitions for EastCoast Colonies simulation
+
+export interface TerrainGrid {
+  W: number; H: number; cellSizeM: number;
+  elevationM: Float32Array; slopeRad: Float32Array;
+  fertility: Uint8Array; soilClass: Uint8Array; moistureIx: Uint8Array;
+  coastline: PolylineSet;
+  nearshoreDepthM: Float32Array;
+}
+
+export interface RiverGraph {
+  nodes: { x: Float32Array; y: Float32Array; flow: Float32Array; };
+  edges: {
+    src: Uint32Array; dst: Uint32Array;
+    lineStart: Uint32Array; lineEnd: Uint32Array;
+    lengthM: Float32Array; widthM: Float32Array; slope: Float32Array;
+    order: Uint8Array; fordability: Float32Array;
+  };
+  lines: PolylineSet; mouthNodeIds: Uint32Array;
+}
+
+export interface HydroNetwork {
+  river: RiverGraph;
+  coast: PolylineSet;
+  fallLine: { nodeIds: Uint32Array; xy: Float32Array };
+  distToRiverM?: Float32Array; distToCoastM?: Float32Array;
+}
+
+export interface LandMesh {
+  sitesX: Float32Array; sitesY: Float32Array;
+  cellStart: Uint32Array; cellCount: Uint32Array;
+  vertsX: Float32Array; vertsY: Float32Array;
+  heTwin: Uint32Array; heNext: Uint32Array; heCell: Uint32Array;
+  heMidX: Float32Array; heMidY: Float32Array; heLen: Float32Array;
+  heIsCoast: Uint8Array; heCrossesRiver: Uint8Array;
+  elevMean: Float32Array; slopeMean: Float32Array;
+  fertility: Uint16Array; soilClass: Uint8Array; moistureIx: Uint8Array;
+  distToRiverM: Float32Array; distToCoastM: Float32Array;
+  areaM2: Float32Array; centroidX: Float32Array; centroidY: Float32Array;
+}
+
+export enum LandUse { Forest = 0, Field = 1, Pasture = 2, Manufactory = 3, Town = 4 }
+
+export interface LandState {
+  use: Uint8Array;
+  forestAgeY: Uint16Array;
+}
+
+export enum RoadClass { Trail = 0, Road = 1, Turnpike = 2 }
+
+export interface NetState {
+  edgeClass: Uint8Array;
+  edgeUsage: Float32Array;
+  ferry: Uint8Array;
+  bridge: Uint8Array;
+  ports: Uint32Array;
+  landings: Uint32Array;
+}
+
+export interface Settlement {
+  cellId: number; pop: number; rank: 0|1|2|3;
+}
+
+export interface RNG {
+  next(): number;
+}
+
+export interface Config {
+  seed: number;
+  map: { size_km: [number, number]; ocean_margin_m: number; sea_level_m: number; };
+  time: { start_year: number; tick: string; gif_every_ticks: number; };
+  worldgen: {
+    relief_strength: number;
+    ridge_orientation_deg: number;
+    river_density: number;
+    harbor: { shelter: number; depth: number; exposure: number };
+  };
+  transport: {
+    overland: boolean; river_navigation: boolean; coastal_shipping: boolean;
+    trail_to_road: number; road_to_turnpike: number;
+    ferry_open: number; bridge_build: number;
+  };
+  landuse: { forest_regrowth_years: number; field_claim_radius_km: number };
+  industries: {
+    mills: boolean; shipyards: boolean; ironworks: boolean; brickworks: boolean; woodworking: boolean;
+    spawn_thresholds: { [k: string]: number };
+  };
+  render: { resolution_px: [number, number]; style: string };
+}
+
+export interface Sim {
+  phys: { terrain: TerrainGrid; hydro: HydroNetwork; land: LandMesh };
+  land: LandState;
+  net: NetState;
+  towns: Settlement[];
+  clock: { year: number; quarter: 0|1|2|3 };
+  rng: RNG;
+  cfg: Config;
+}
+
+export interface ODBundle {
+  from: number;
+  to: number;
+  quantity: number;
+}
+
+export interface PolylineSet {
+  // Placeholder for geometry collection
+  lines: Float32Array;
+  offsets: Uint32Array;
+}

--- a/src/worldgen.ts
+++ b/src/worldgen.ts
@@ -1,0 +1,18 @@
+import { Config, RNG, TerrainGrid, HydroNetwork, LandMesh } from './types';
+
+export function generateTerrain(cfg: Config, rng: RNG): TerrainGrid {
+  throw new Error('generateTerrain not implemented');
+}
+
+export function buildHydro(terrain: TerrainGrid, cfg: Config): HydroNetwork {
+  throw new Error('buildHydro not implemented');
+}
+
+export function buildLandMesh(
+  terrain: TerrainGrid,
+  hydro: HydroNetwork,
+  cfg: Config,
+  rng: RNG
+): LandMesh {
+  throw new Error('buildLandMesh not implemented');
+}

--- a/tests/stubs.test.ts
+++ b/tests/stubs.test.ts
@@ -1,0 +1,35 @@
+import {
+  generateTerrain,
+  buildHydro,
+  buildLandMesh
+} from '../src/worldgen';
+import {
+  initNetwork,
+  edgeCost,
+  buildOD,
+  routeFlowsAndAccumulateUsage,
+  applyUpgrades
+} from '../src/transport';
+import {
+  updateLandUse,
+  updateSettlements,
+  updateIndustries
+} from '../src/growth';
+import { renderFrame } from '../src/render';
+import { captureIfDue } from '../src/export_gif';
+
+test('stub functions exist', () => {
+  expect(typeof generateTerrain).toBe('function');
+  expect(typeof buildHydro).toBe('function');
+  expect(typeof buildLandMesh).toBe('function');
+  expect(typeof initNetwork).toBe('function');
+  expect(typeof edgeCost).toBe('function');
+  expect(typeof buildOD).toBe('function');
+  expect(typeof routeFlowsAndAccumulateUsage).toBe('function');
+  expect(typeof applyUpgrades).toBe('function');
+  expect(typeof updateLandUse).toBe('function');
+  expect(typeof updateSettlements).toBe('function');
+  expect(typeof updateIndustries).toBe('function');
+  expect(typeof renderFrame).toBe('function');
+  expect(typeof captureIfDue).toBe('function');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- initialize TypeScript project with eslint, prettier, and vitest configuration
- add core data model interfaces and placeholder modules for worldgen, transport, growth, render, and GIF export
- document module stubs and mark project setup step complete

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f4e2ff848324b7a8a4fffe9769ff