### PR TITLE
docs: record project brief and architecture

### DIFF
--- a/docs/steps/01_core_world.md
+++ b/docs/steps/01_core_world.md
@@ -8,7 +8,7 @@ Implement the foundational world generation and hydrology systems.
 - [x] Run hydrology model to ensure rivers flow to ocean and avoid sinks.
 - Score coastline for harbor suitability and place a single initial port.
 - Output raster grids: height, flow accumulation, moisture.
-- Document algorithms and data structures in [`docs/architecture.md`](../architecture.md).
+- [x] Document algorithms and data structures in [`docs/architecture.md`](../architecture.md).
 
 ## Testing & Acceptance
 - Given default config, rivers reach the ocean without infinite loops.


### PR DESCRIPTION
## Summary
- Replace outdated design overview with current project brief, determinism rules, and module layout
- Align architecture document with new physical, land-use, network, simulation, and rendering layers
- Describe how terrain, hydrology, and land mesh form the physical layer
- Mark Step 1 checklist item for documenting algorithms and data structures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b227780f3c8324ae2c301214de4977