### PR TITLE
feat: add deterministic terrain noise

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,8 +26,7 @@ Interfaces for these modules reside in [`src/types.ts`](../src/types.ts).
 
 ## Physical Layer
 World generation builds three immutable structures in sequence:
-1. `generateTerrain` creates a `TerrainGrid` raster from noise, fills depressions,
-   derives slope and fertility and traces the coastline with near‑shore depth samples.
+1. `generateTerrain` creates a `TerrainGrid` raster from simplex noise seeded via the game RNG. Relief strength and ridge orientation come from `cfg.worldgen`, then slope and fertility are derived before tracing the coastline with near‑shore depth samples.
 2. `buildHydro` runs flow direction and accumulation over the terrain to extract rivers,
    simplify polylines and construct a directed `RiverGraph` with width, order and fall‑line markers.
 3. `buildLandMesh` Poisson‑samples land sites (denser near water), forms a Delaunay triangulation
@@ -37,4 +36,4 @@ World generation builds three immutable structures in sequence:
 These datasets are read‑only foundations for higher layers.
 
 ## Current Implementation Details
-The prototype world generator produces a 1 km grid with a single straight river and a one‑cell land mesh so downstream systems can be exercised deterministically during Step 1.
+The prototype world generator produces a 1 km grid using seeded simplex noise with adjustable ridge orientation. It derives per‑cell slope and fertility, then adds a single straight river and a one‑cell land mesh so downstream systems can be exercised deterministically during Step 1.

--- a/docs/steps/01_core_world.md
+++ b/docs/steps/01_core_world.md
@@ -5,6 +5,7 @@ Implement the foundational world generation and hydrology systems.
 ## Tasks
 - [x] Implement seeded RNG and JSON configuration loader.
 - [x] Generate 10×10 km height map using noise with ridge orientation controls.
+- [x] Derive slope and fertility from the height map.
 - [x] Run hydrology model to ensure rivers flow to ocean and avoid sinks.
 - Score coastline for harbor suitability and place a single initial port.
 - Output raster grids: height, flow accumulation, moisture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "ajv": "^8.12.0"
+        "ajv": "^8.12.0",
+        "simplex-noise": "^4.0.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -2997,6 +2998,12 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "simplex-noise": "^4.0.3"
   },
   "devDependencies": {
-    "typescript": "^5.0.0",
-    "vitest": "^0.34.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "prettier": "^2.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^0.34.0"
   }
 }

--- a/src/physical/noise.ts
+++ b/src/physical/noise.ts
@@ -1,0 +1,9 @@
+import { createNoise2D as simplexCreateNoise2D } from 'simplex-noise';
+import { RNG } from '../types';
+
+/**
+ * Wrap the simplex-noise generator to use the game's RNG for determinism.
+ */
+export function createNoise2D(rng: RNG) {
+  return simplexCreateNoise2D(() => rng.next());
+}

--- a/tests/physical.test.ts
+++ b/tests/physical.test.ts
@@ -12,6 +12,17 @@ test('generateTerrain produces grid with coastline', () => {
   expect(terrain.coastline.lines[0]).toBeCloseTo(expectedCoastX);
 });
 
+test('generateTerrain deterministic for seed', () => {
+  const terrain1 = generateTerrain(defaultConfig, rng());
+  const terrain2 = generateTerrain(defaultConfig, rng());
+  const idx = 5 * defaultConfig.map.size_km[0] + 5;
+  expect(terrain1.elevationM[idx]).toBeCloseTo(54.182529, 5);
+  expect(terrain1.slopeRad[idx]).toBeCloseTo(0.00577, 5);
+  expect(terrain1.fertility[idx]).toBe(254);
+  expect(terrain1.elevationM[idx]).toBeCloseTo(terrain2.elevationM[idx]);
+  expect(terrain1.fertility[idx]).toBe(terrain2.fertility[idx]);
+});
+
 test('buildHydro creates river reaching the coast', () => {
   const terrain = generateTerrain(defaultConfig, rng());
   const hydro = buildHydro(terrain, defaultConfig);


### PR DESCRIPTION
## Summary
- incorporate simplex-noise and RNG wrapper for deterministic elevation
- derive slope and fertility from seeded elevation grid
- test terrain determinism for default seed

## Testing
- `npm run lint`
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b2aa4043088324928bcbad66719c26)