### PR TITLE
feat: export debug rasters

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,5 +36,8 @@ World generation builds three immutable structures in sequence:
 
 These datasets are read‑only foundations for higher layers.
 
+When `cfg.debug.worldgen` is true, `generateTerrain` and `buildHydro` export raw `elevation`,
+`moisture` and `flow` arrays to JSON files in a `debug/` directory for inspection.
+
 ## Current Implementation Details
 The prototype world generator produces a 1 km grid with a single straight river and a one‑cell land mesh so downstream systems can be exercised deterministically during Step 1.

--- a/docs/steps/01_core_world.md
+++ b/docs/steps/01_core_world.md
@@ -7,7 +7,7 @@ Implement the foundational world generation and hydrology systems.
 - [x] Generate 10×10 km height map using noise with ridge orientation controls.
 - [x] Run hydrology model to ensure rivers flow to ocean and avoid sinks.
 - Score coastline for harbor suitability and place a single initial port.
-- Output raster grids: height, flow accumulation, moisture.
+- [x] Output raster grids: height, flow accumulation, moisture.
 - [x] Document algorithms and data structures in [`docs/architecture.md`](../architecture.md).
 
 ## Testing & Acceptance

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -35,4 +35,5 @@ export const defaultConfig: Config = {
     },
   },
   render: { resolution_px: [1600, 1200], style: 'classical' },
+  debug: { worldgen: false },
 };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -121,5 +121,13 @@ export const configSchema: JSONSchemaType<Config> = {
         style: { type: 'string' },
       },
     },
+    debug: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['worldgen'],
+      properties: {
+        worldgen: { type: 'boolean' },
+      },
+    },
   },
 };

--- a/src/physical/generate.ts
+++ b/src/physical/generate.ts
@@ -1,4 +1,6 @@
 import { Config, RNG, TerrainGrid, HydroNetwork, LandMesh, PolylineSet } from '../types';
+import fs from 'node:fs';
+import path from 'node:path';
 
 /**
  * Deterministic toy terrain generator used for early testing. The map is
@@ -40,7 +42,7 @@ export function generateTerrain(cfg: Config, rng: RNG): TerrainGrid {
   };
   const nearshoreDepthM = new Float32Array([10, 10]);
 
-  return {
+  const terrain: TerrainGrid = {
     W,
     H,
     cellSizeM,
@@ -52,6 +54,15 @@ export function generateTerrain(cfg: Config, rng: RNG): TerrainGrid {
     coastline: coastLine,
     nearshoreDepthM,
   };
+
+  if (cfg.debug?.worldgen) {
+    const outDir = path.join(process.cwd(), 'debug');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'elevation.json'), JSON.stringify(Array.from(elevationM)));
+    fs.writeFileSync(path.join(outDir, 'moisture.json'), JSON.stringify(Array.from(moistureIx)));
+  }
+
+  return terrain;
 }
 
 /**
@@ -91,6 +102,12 @@ export function buildHydro(terrain: TerrainGrid, cfg: Config): HydroNetwork {
   };
 
   const river = { nodes, edges, lines: riverLine, mouthNodeIds: new Uint32Array([2]) };
+
+  if (cfg.debug?.worldgen) {
+    const outDir = path.join(process.cwd(), 'debug');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'flow.json'), JSON.stringify(Array.from(nodes.flow)));
+  }
 
   const fallLine = {
     nodeIds: new Uint32Array([1]),

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface Config {
     spawn_thresholds: { [k: string]: number };
   };
   render: { resolution_px: [number, number]; style: string };
+  debug?: { worldgen: boolean };
 }
 
 export interface Sim {

--- a/tests/physical.test.ts
+++ b/tests/physical.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest';
 import { generateTerrain, buildHydro, buildLandMesh } from '../src/physical/generate';
 import { defaultConfig } from '../src/config';
 import { createRNG } from '../src/core/rng';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const rng = () => createRNG(defaultConfig.seed);
 
@@ -26,4 +28,16 @@ test('buildLandMesh returns single coastal cell', () => {
   const mesh = buildLandMesh(terrain, hydro, defaultConfig, rng());
   expect(mesh.cellCount.length).toBe(1);
   expect(Array.from(mesh.heIsCoast)).toContain(1);
+});
+
+test('debug flag writes terrain and hydro rasters', () => {
+  const cfg = { ...defaultConfig, debug: { worldgen: true } };
+  const outDir = path.join(process.cwd(), 'debug');
+  fs.rmSync(outDir, { recursive: true, force: true });
+  const terrain = generateTerrain(cfg, rng());
+  buildHydro(terrain, cfg);
+  expect(fs.existsSync(path.join(outDir, 'elevation.json'))).toBe(true);
+  expect(fs.existsSync(path.join(outDir, 'moisture.json'))).toBe(true);
+  expect(fs.existsSync(path.join(outDir, 'flow.json'))).toBe(true);
+  fs.rmSync(outDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- add `debug.worldgen` flag to configuration
- dump terrain elevation, moisture, and river flow arrays when flag enabled
- verify debug export files through new physical layer test

## Testing
- `npm test -- --run`
- `npm run lint`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b2ab07fcdc8324af4b81224370f891)