### PR TITLE
Implement hydrology-aware land mesh

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,11 @@ World generation builds three immutable structures in sequence:
 2. `buildHydro` runs D∞ flow direction and accumulation over the terrain, using a small eastward tilt to bias outlets toward the coast. Accumulation is converted into channels based on `cfg.worldgen.river_density`, then traced into polylines that terminate at coastal mouth nodes. Each directed edge stores discharge, width, slope and Strahler order, and fall‑line nodes are flagged where downstream slopes exceed a threshold.
 3. `buildLandMesh` Poisson‑samples land sites (denser near water), forms a Delaunay triangulation
    and Voronoi diagram clipped to land, then annotates cells and half‑edges with terrain and hydro
-   attributes including `heCrossesRiver` and `heIsCoast` flags.
+   attributes including `heCrossesRiver` and `heIsCoast` flags. The Voronoi polygons are built from
+   a D3 Delaunay and bounded by the coastline rectangle; half‑edges are paired by shared vertices,
+   tagged when they lie on the coastal boundary and checked for intersection against river polylines.
 
 These datasets are read‑only foundations for higher layers.
 
 ## Current Implementation Details
-The prototype world generator produces a 1 km grid using seeded simplex noise with adjustable ridge orientation. It derives per‑cell slope and fertility, then computes D∞ routing and flow accumulation to extract a river graph that conserves discharge to the coastline. River polylines are simplified into directed edges with width, order and fordability estimates, fall‑line nodes are marked on steep downstream reaches, and a one‑cell land mesh is retained so downstream systems can be exercised deterministically during Step 1.
+The prototype world generator produces a 1 km grid using seeded simplex noise with adjustable ridge orientation. It derives per‑cell slope and fertility, then computes D∞ routing and flow accumulation to extract a river graph that conserves discharge to the coastline. River polylines are simplified into directed edges with width, order and fordability estimates, and fall‑line nodes are marked on steep downstream reaches. The land mesh now Poisson‑samples hundreds of coastal‑biased sites, builds a Delaunay/Voronoi diagram clipped to the land rectangle, and fills half‑edge connectivity with coast and river‑intersection flags plus per‑cell terrain attributes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",
+        "d3-delaunay": "^6.0.4",
         "simplex-noise": "^4.0.3"
       },
       "devDependencies": {
@@ -1615,6 +1616,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1652,6 +1665,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -2891,6 +2913,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.49.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "ajv": "^8.12.0",
+    "d3-delaunay": "^6.0.4",
     "simplex-noise": "^4.0.3"
   },
   "devDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface LandMesh {
   cellStart: Uint32Array; cellCount: Uint32Array;
   vertsX: Float32Array; vertsY: Float32Array;
   heTwin: Uint32Array; heNext: Uint32Array; heCell: Uint32Array;
+  heVertA: Uint32Array; heVertB: Uint32Array;
   heMidX: Float32Array; heMidY: Float32Array; heLen: Float32Array;
   heIsCoast: Uint8Array; heCrossesRiver: Uint8Array;
   elevMean: Float32Array; slopeMean: Float32Array;


### PR DESCRIPTION
## Summary
- build a Voronoi land mesh from Poisson-sampled sites biased toward rivers and the coast, tagging half-edges for coastal and river intersections
- extend land mesh typing and add physical layer tests that check half-edge consistency and river crossing flags
- document the physical layer update and add the D3 Delaunay dependency

## Testing
- npm run lint
- npx vitest run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455c4910788324ac7f173affce1011)